### PR TITLE
 Fix exception raised when target is not found 

### DIFF
--- a/src/components/VStep.vue
+++ b/src/components/VStep.vue
@@ -92,7 +92,7 @@ export default {
     }
   },
   emits: ['targetNotFound'],
-  setup(props) {
+  setup(props, context) {
     const hash = sum(props.step.target)
     const targetElement = document.querySelector(props.step.target)
 
@@ -127,7 +127,7 @@ export default {
         if (props.debug) {
           console.error('[Vue Tour] The target element ' + props.step.target + ' of .v-step[id="' + hash + '"] does not exist!')
         }
-        props.$emit('targetNotFound', props.step)
+        context.emit('targetNotFound', props.step)
         if (props.stopOnFail) {
           props.stop()
         }

--- a/src/lib.js
+++ b/src/lib.js
@@ -1,4 +1,4 @@
-import VTour from './components/Vtour.vue'
+import VTour from './components/VTour.vue'
 import VStep from './components/VStep.vue'
 
 const install = (app) => {


### PR DESCRIPTION
Fix a `xx.$emit is not a function` exception (#3),
occurring when target is not found,
by using context and context.emit.

Also fix compilation error due to import case.