### PR TITLE
Popper 2.11.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,8 @@
     "": {
       "version": "0.1.0",
       "dependencies": {
+        "@popperjs/core": "^2.11.5",
         "jump.js": "^1.0.2",
-        "popper.js": "^1.16.1",
         "vue": "^3.0.5"
       },
       "devDependencies": {
@@ -42,6 +42,15 @@
         "@babel/helper-validator-identifier": "^7.12.11",
         "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@vitejs/plugin-vue": {
@@ -539,16 +548,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/postcss": {
       "version": "8.2.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.8.tgz",
@@ -835,6 +834,11 @@
         "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@popperjs/core": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
     },
     "@vitejs/plugin-vue": {
       "version": "1.1.5",
@@ -1231,11 +1235,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
-    },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "postcss": {
       "version": "8.2.8",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "serve": "vite preview"
   },
   "dependencies": {
+    "@popperjs/core": "^2.11.5",
     "jump.js": "^1.0.2",
-    "popper.js": "^1.16.1",
     "vue": "^3.0.5"
   },
   "devDependencies": {

--- a/src/components/VStep.vue
+++ b/src/components/VStep.vue
@@ -33,7 +33,7 @@
 
 <script>
 import { ref, computed, onMounted, onUnmounted } from 'vue'
-import Popper from 'popper.js'
+import { createPopper } from '@popperjs/core'
 import jump from 'jump.js'
 import sum from 'hash-sum'
 import { DEFAULT_STEP_OPTIONS, HIGHLIGHT } from '../shared/constants'
@@ -117,8 +117,7 @@ export default {
         enableScrolling()
         createHighlight()
 
-        /* eslint-disable no-new */
-        new Popper(
+        createPopper(
           targetElement,
           VStep.value,
           params.value


### PR DESCRIPTION
Upgrades the Popper dependency to their latest major version. Doesn't seem to break the demo, but I haven't tested this thoroughly.