### PR TITLE
fix popperjs arrow placement

### DIFF
--- a/src/components/VStep.vue
+++ b/src/components/VStep.vue
@@ -30,7 +30,7 @@
       </div>
     </slot>
 
-    <div class="v-step__arrow" :class="{ 'v-step__arrow--dark': step.header && step.header.title }"></div>
+    <div class="v-step__arrow" :class="{ 'v-step__arrow--dark': step.header && step.header.title }" data-popper-arrow></div>
   </div>
   <!-- </teleport> -->
 </template>


### PR DESCRIPTION
The arrow placement wasn't calculated correctly as the `data-popper-arrow` attribute within the _VStep_ component was missing. By adding this, it works again. 