### PR TITLE
Fix: Make vstep without target works

### DIFF
--- a/src/components/VStep.vue
+++ b/src/components/VStep.vue
@@ -119,10 +119,7 @@ export default {
       if (props.debug) {
         console.log('[Vue Tour] The target element ' + props.step.target + ' of .v-step[id="' + hash + '"] is:', targetElement)
       }
-
-      if (isSticky.value) {
-        document.body.appendChild(VStep)
-      } else {
+      if (!isSticky.value) {
         if (targetElement) {
           enableScrolling()
           createHighlight()
@@ -190,7 +187,7 @@ export default {
     }
 
     const removeHighlight = () => {
-      if (isHighlightEnabled()) {
+      if (isHighlightEnabled() && targetElement) {
         const currentTransition = targetElement.style.transition
         targetElement.classList.remove(HIGHLIGHT.CLASSES.TARGET_HIGHLIGHTED)
         targetElement.classList.remove(HIGHLIGHT.CLASSES.TARGET_RELATIVE)


### PR DESCRIPTION
Hello,

Was trying to create a VStep without target but could not succeed due to an error.
I got the feeling that `document.body.appendChild(VStep)` was not necessary (It was the line causing me the bugs).

Then there was an issue with the removeHighlight, I just reproduced the fix they did on the original repository.

Thank for giving a look at my PR ! 