### PR TITLE
Fixed keypress attached always

### DIFF
--- a/example/components/Tour.vue
+++ b/example/components/Tour.vue
@@ -34,12 +34,13 @@
           }
         ],
         options: {
-            highlight: true
+            highlight: true,
+            debug: true 
         }
       }
     },
     mounted: function () {
-      this.$tours['myTour'].start()
+      // this.$tours['myTour'].start()
     }
   }
 </script>

--- a/src/components/VTour.vue
+++ b/src/components/VTour.vue
@@ -1,45 +1,45 @@
 <template>
   <div class="v-tour">
     <slot
-      :current-step="currentStep"
-      :steps="steps"
-      :previous-step="previousStep"
-      :next-step="nextStep"
-      :stop="stop"
-      :skip="skip"
-      :finish="finish"
-      :is-first="isFirst"
-      :is-last="isLast"
-      :labels="customOptions.labels"
-      :enabled-buttons="customOptions.enabledButtons"
-      :highlight="customOptions.highlight"
-      :debug="customOptions.debug"
+    :current-step="currentStep"
+    :steps="steps"
+    :previous-step="previousStep"
+    :next-step="nextStep"
+    :stop="stop"
+    :skip="skip"
+    :finish="finish"
+    :is-first="isFirst"
+    :is-last="isLast"
+    :labels="customOptions.labels"
+    :enabled-buttons="customOptions.enabledButtons"
+    :highlight="customOptions.highlight"
+    :debug="customOptions.debug"
     >
-      <!--Default slot {{ currentStep }}-->
-      <v-step
-        v-if="steps[currentStep]"
-        :step="steps[currentStep]"
-        :key="currentStep"
-        :previous-step="previousStep"
-        :next-step="nextStep"
-        :stop="stop"
-        :skip="skip"
-        :finish="finish"
-        :is-first="isFirst"
-        :is-last="isLast"
-        :labels="customOptions.labels"
-        :enabled-buttons="customOptions.enabledButtons"
-        :highlight="customOptions.highlight"
-        :stop-on-fail="customOptions.stopOnTargetNotFound"
-        :debug="customOptions.debug"
-        @targetNotFound="$emit('targetNotFound', $event)"
-      >
-        <!--<div v-if="index === 2" slot="actions">
-          <a @click="nextStep">Next step</a>
-        </div>-->
-      </v-step>
-    </slot>
-  </div>
+    <!--Default slot {{ currentStep }}-->
+    <v-step
+    v-if="steps[currentStep]"
+    :step="steps[currentStep]"
+    :key="currentStep"
+    :previous-step="previousStep"
+    :next-step="nextStep"
+    :stop="stop"
+    :skip="skip"
+    :finish="finish"
+    :is-first="isFirst"
+    :is-last="isLast"
+    :labels="customOptions.labels"
+    :enabled-buttons="customOptions.enabledButtons"
+    :highlight="customOptions.highlight"
+    :stop-on-fail="customOptions.stopOnTargetNotFound"
+    :debug="customOptions.debug"
+    @targetNotFound="$emit('targetNotFound', $event)"
+    >
+    <!--<div v-if="index === 2" slot="actions">
+      <a @click="nextStep">Next step</a>
+    </div>-->
+  </v-step>
+</slot>
+</div>
 </template>
 
 <script>
@@ -67,32 +67,34 @@ export default {
   },
   setup (props, ctx) {
     const currentStep = ref(-1)
-
+    
     const customOptions = computed(() => {
       return {
         ...DEFAULT_OPTIONS,
         ...props.options
       }
     })
-
+    
     const customCallbacks = computed(() => {
       return {
         ...DEFAULT_CALLBACKS,
         ...props.callbacks
       }
     })
-
+    
     const isRunning = computed(() => currentStep.value > -1 && currentStep.value < numberOfSteps.value)
-
+    
     const isFirst = computed(() => currentStep.value === 0)
-
+    
     const isLast = computed(() => currentStep.value === props.steps.length - 1)
-
+    
     const numberOfSteps = computed(() => props.steps.length)
-
+    
     const step = computed(() => props.steps[currentStep.value])
-
+    
     const start = async (startStep) => {
+      attachKeyPressHandler()
+      
       // Wait for the DOM to be loaded, then start the tour
       startStep = typeof startStep !== 'undefined' ? parseInt(startStep, 10) : 0
       let step = props.steps[startStep]
@@ -113,7 +115,7 @@ export default {
       await process()
       return Promise.resolve()
     }
-
+    
     const previousStep = async () => {
       let futureStep = currentStep.value - 1
       let process = () => new Promise((resolve, reject) => {
@@ -134,7 +136,7 @@ export default {
       }
       return Promise.resolve()
     }
-
+    
     const nextStep = async () => {
       let futureStep = currentStep.value + 1
       let process = () => new Promise((resolve, reject) => {
@@ -155,77 +157,86 @@ export default {
       }
       return Promise.resolve()
     }
-
+    
     const stop = () => {
       customCallbacks.value.onStop()
       document.body.classList.remove('v-tour--active')
       currentStep.value = -1
+      removeKeyPressHandler()
     }
-
+    
     const skip = () => {
       customCallbacks.value.onSkip()
       stop()
     }
-
+    
     const finish = () => {
-      customCallbacks.value.onFinish()
+      customCallbacks.value.onFinish() 
       stop()
     }
-
+    
     const handleKeyup = (e) => {
       if (customOptions.value.debug) {
         console.log('[Vue Tour] A keyup event occured:', e)
       }
+      
       switch (e.keyCode) {
         case KEYS.ARROW_RIGHT:
-          isKeyEnabled('ARROW_RIGHT') && nextStep()
-          break
+        isKeyEnabled('ARROW_RIGHT') && nextStep()
+        break
         case KEYS.ARROW_LEFT:
-          isKeyEnabled('ARROW_LEFT') && previousStep()
-          break
+        isKeyEnabled('ARROW_LEFT') && previousStep()
+        break
         case KEYS.ESCAPE:
-          isKeyEnabled('ESCAPE') && stop()
-          break
+        isKeyEnabled('ESCAPE') && stop()
+        break
       }
     }
-
+    
     const isKeyEnabled = (key) => {
       const { enabledNavigationKeys } = customOptions.value
       return enabledNavigationKeys.hasOwnProperty(key) ? enabledNavigationKeys[key] : true
     }
-
-    onMounted(() => {
-      const app = getCurrentInstance()
-      app.appContext.config.globalProperties.$tours[props.name] = { step, start, isRunning, customOptions, currentStep, isFirst, isLast, previousStep, nextStep, stop, skip, finish, numberOfSteps }
+    
+    const attachKeyPressHandler = () =>{
       if (customOptions.value.useKeyboardNavigation) {
         window.addEventListener('keyup', handleKeyup)
       }
-    })
-
-    onBeforeUnmount(() => {
+    }
+    
+    const removeKeyPressHandler = () =>{
       if (customOptions.value.useKeyboardNavigation) {
         window.removeEventListener('keyup', handleKeyup)
       }
+    }
+    
+    onMounted(() => {
+      const app = getCurrentInstance()
+      app.appContext.config.globalProperties.$tours[props.name] = { step, start, isRunning, customOptions, currentStep, isFirst, isLast, previousStep, nextStep, stop, skip, finish, numberOfSteps }
     })
-
+    
+    onBeforeUnmount(() => {
+      removeKeyPressHandler()
+    })
+    
     return { customOptions, currentStep, isFirst, isLast, previousStep, nextStep, stop, skip, finish }
   }
 }
 </script>
 
 <style lang="scss">
-  body.v-tour--active {
-    pointer-events: none;
-  }
-  .v-tour {
-    pointer-events: auto;
-  }
-  .v-tour__target--highlighted {
-    box-shadow: 0 0 0 4px rgba(0,0,0,.4);
-    pointer-events: auto;
-    z-index: 9999;
-  }
-  .v-tour__target--relative {
-    position: relative;
-  }
+body.v-tour--active {
+  pointer-events: none;
+}
+.v-tour {
+  pointer-events: auto;
+}
+.v-tour__target--highlighted {
+  box-shadow: 0 0 0 4px rgba(0,0,0,.4);
+  pointer-events: auto;
+  z-index: 9999;
+}
+.v-tour__target--relative {
+  position: relative;
+}
 </style>


### PR DESCRIPTION
Hello, I noticed that when the tour has not started, the library always listens to the **keyup event**.
This event should only be listened to when a tour starts. It should also stop listening when it is stopped, skipped or the current page is about to be unmounted.