### PR TITLE
Update package.json to include 'types' directory in files

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "types"
   ],
   "main": "dist/vue3-tour.umd.js",
   "browser": "dist/vue3-tour.umd.js",


### PR DESCRIPTION
Type declarations have been added, but they are not present when `vue3-tour` is included as a dependency. This change adds the `types` directory to the `files` property in `package.json` so that the declarations are included in the files published to the registry.