### PR TITLE
Correct entrypoint file names

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "src",
     "types"
   ],
-  "main": "dist/vue3-tour.umd.js",
-  "browser": "dist/vue3-tour.umd.js",
+  "main": "dist/vue3-tour.umd.cjs",
+  "browser": "dist/vue3-tour.umd.cjs",
   "module": "dist/vue3-tour.js",
   "types": "types/vue3-tour.d.ts",
   "repository": {


### PR DESCRIPTION
Since 1.0.0, the `dist` folder has included a `vue3-tour.umd.cjs` file, but the manifest is still referring to a `vue3-tour.umd.js` file which causes issues in certain environments (we're seeing a `Error: Failed to resolve entry for package "vue3-tour". The package may have incorrect main/module/exports specified in its package.json.` error in the CI for one of our projects after adding this package).  This will fix the manifest by making the filenames match the actual output.